### PR TITLE
Update thing-types.xml

### DIFF
--- a/target/classes/ESH-INF/thing/thing-types.xml
+++ b/target/classes/ESH-INF/thing/thing-types.xml
@@ -255,6 +255,16 @@
 <option value="98">98 Percent</option>
 <option value="99">99 RippleRainbow</option>
 <option value="100">100 Heartbeat</option>
+<option value="101">101 Pacifica</option>
+<option value="102">102 Candle Multi</option>
+<option value="103">103 Solid Glitter</option>
+<option value="104">104 Sunrise</option>
+<option value="105">105 Phased</option>
+<option value="106">106 Twinkle Up</option>
+<option value="107">107 Noise Pal</option>
+<option value="108">108 Sinewave</option>
+<option value="109">109 Phased Noise</option>
+<option value="110">110 Flow</option>
 </options>
 </state>
 </channel-type>


### PR DESCRIPTION
Added missing effects

PACIFICA, 101
CANDLE_MULTI, 102
SOLID_GLITTER, 103
SUNRISE, 104
PHASED, 105
TWINKLEUP, 106
NOISEPA, 107
SINEWAVE, 108
PHASEDNOISE, 109
FLOW, 110

according to Efffect Index (FX) from https://github.com/Skinah/wled/blob/master/target/classes/ESH-INF/thing/thing-types.xml